### PR TITLE
Added more nginx commands, since my server needed a 'nginx:start' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # This Fork
 
-This fork provides specific adjustments in order to make it compatible with RedHat-like OS's.
+This fork provides specific adjustments to work with Amazon Linux (which in turn is Redhat-based).
+
+This means that some commands are different:
+
+* using `chkconfig` instead of update-rc.d
+* assuming `nginx` is installed and available at `/etc/nginx`
+* assuming configuration for nginx lives at `/etc/conf.d/[ENV_NAME].conf
 
 All credit to irlrobot.
 

--- a/capistrano-unicorn-nginx.gemspec
+++ b/capistrano-unicorn-nginx.gemspec
@@ -4,9 +4,9 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'capistrano/unicorn_nginx/version'
 
 Gem::Specification.new do |gem|
-  gem.name          = "capistrano-unicorn-nginx"
+  gem.name          = "capistrano-unicorn-nginx-ami"
   gem.version       = Capistrano::UnicornNginx::VERSION
-  gem.authors       = ["Ruben Stranders", "Bruno Sutic"]
+  gem.authors       = ["Ruben Stranders", "Bruno Sutic", "Jesper Rønn-Jensen"]
   gem.email         = ["r.stranders@gmail.com", "bruno.sutic@gmail.com"]
   gem.description   = <<-EOF.gsub(/^\s+/, '')
     Capistrano tasks for automatic  and sensible unicorn + nginx configuraion.
@@ -14,11 +14,13 @@ Gem::Specification.new do |gem|
     Enables zero downtime deployments of Rails applications. Configs can be
     copied to the application using generators and easily customized.
 
+    This fork is customized for Redhat-based nginx systems. For example Amazon Linux.
+
     Works *only* with Capistrano 3+. For Capistrano 2 try version 0.0.8 of this
     gem: http://rubygems.org/gems/capistrano-nginx-unicorn
   EOF
   gem.summary       = "Capistrano tasks for automatic and sensible unicorn + nginx configuraion."
-  gem.homepage      = "https://github.com/bruno-/capistrano-unicorn-nginx"
+  gem.homepage      = "https://github.com/jesperronn/capistrano-unicorn-nginx-ami"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -62,10 +62,16 @@ namespace :nginx do
     end
   end
 
-  desc 'Reload nginx configuration'
-  task :reload do
-    on roles :web do
-      sudo nginx_service_path, 'reload'
+  # will generate all commands that nginx supports, for instance:
+  # cap ENV nginx:start
+  # cap ENV nginx:reload
+  # cap ENV nginx:configtest
+  %w(start stop reload configtest status force-reload upgrade restart reopen_logs).each do |tsk|
+    desc %('#{tsk.capitalize}' nginx command)
+    task tsk do
+      on roles :web do
+        sudo nginx_service_path, tsk
+      end
     end
   end
 

--- a/lib/capistrano/unicorn_nginx/version.rb
+++ b/lib/capistrano/unicorn_nginx/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module UnicornNginx
-    VERSION = "3.4.0"
+    VERSION = "4.0.0"
   end
 end


### PR DESCRIPTION
The following commands are now available for nginx:

```
cap ENV nginx:start
cap ENV nginx:stop
cap ENV nginx:reload
cap ENV nginx:configtest
cap ENV nginx:status
cap ENV nginx:force-reload
cap ENV nginx:upgrade
cap ENV nginx:restart
cap ENV nginx:reopen_logs
```

@erwald I chose to target your branch, because your changes work for an Amazon Linux. 
